### PR TITLE
fix:修复m_layoutMetrics.frame.size.height在集成demo中获取高度不正确的问题

### DIFF
--- a/harmony/nested_scroll/src/main/cpp/NestedScrollViewComponentInstance.cpp
+++ b/harmony/nested_scroll/src/main/cpp/NestedScrollViewComponentInstance.cpp
@@ -38,6 +38,8 @@ NestedScrollViewComponentInstance::NestedScrollViewComponentInstance(Context con
 
 void NestedScrollViewComponentInstance::onFinalizeUpdates() {
   ComponentInstance::onFinalizeUpdates();
+    float scrollHeight = headerHeight - rNCNestedScrollViewHeaderNative->stickyHeaderHeight;
+    fixColumnAll.setHeight(layoutMetricsHeight + scrollHeight);
     mNestedScrollNode.insertChild(fixColumnAll, 0);
     mNestedScrollNode.setAlignment(ARKUI_ALIGNMENT_TOP);
 }
@@ -48,16 +50,20 @@ void NestedScrollViewComponentInstance::onChildInserted(
     if (childComponentInstance->getComponentName() == "RNCNestedScrollViewHeaderNative") {
         elementPositionRelativeFixHeader = true;//记录元素在固定的头部还是尾部
         rNCNestedScrollViewHeaderNative = std::dynamic_pointer_cast<NestedScrollViewHeaderComponentInstance>(childComponentInstance);
-        float scrollHeight = childComponentInstance->getLayoutMetrics().frame.size.height - 
-            rNCNestedScrollViewHeaderNative->stickyHeaderHeight;
-        fixColumnAll.setHeight(m_layoutMetrics.frame.size.height + scrollHeight);
+        headerHeight = childComponentInstance->getLayoutMetrics().frame.size.height;
         fixColumnAll.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
     } else {
         handleScrollView(childComponentInstance);
-        childComponentInstance->getLocalRootArkUINode().setHeight(m_layoutMetrics.frame.size.height - rNCNestedScrollViewHeaderNative->stickyHeaderHeight);
         fixColumnAll.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
     }
 }
+
+void NestedScrollViewComponentInstance::onLayoutChanged(
+    const facebook::react::LayoutMetrics& layoutMetrics) {
+    CppComponentInstance::onLayoutChanged(layoutMetrics);
+    layoutMetricsHeight = layoutMetrics.frame.size.height;
+}
+
 
 void NestedScrollViewComponentInstance::handleScrollView(ComponentInstance::Shared childComponentInstance){
      if (OH_ArkUI_NodeUtils_GetNodeType(childComponentInstance->getLocalRootArkUINode().getArkUINodeHandle()) == 

--- a/harmony/nested_scroll/src/main/cpp/NestedScrollViewComponentInstance.h
+++ b/harmony/nested_scroll/src/main/cpp/NestedScrollViewComponentInstance.h
@@ -46,6 +46,8 @@ public:
     NestedScrollViewNode mNestedScrollNode;
     NestedScrollViewHeaderNode fixColumnAll;
     void onFinalizeUpdates();
+    float headerHeight = 0;
+    float layoutMetricsHeight = 0;
     NestedScrollViewComponentInstance(Context context);
     void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
 
@@ -53,7 +55,8 @@ public:
     NestedScrollViewNode &getLocalRootArkUINode() override;
     void onPropsChanged(SharedConcreteProps const &props) override;
     void onScroll(facebook::react::NestedScrollViewEventEmitter::NestedScrollEvent nestedScrollEvent) override;
-    
+    void onLayoutChanged(
+      const facebook::react::LayoutMetrics& layoutMetrics) override;
     void handleScrollView(ComponentInstance::Shared childComponentInstance);
 };
 } // namespace rnoh

--- a/harmony/nested_scroll/src/main/cpp/NestedScrollViewPackage.h
+++ b/harmony/nested_scroll/src/main/cpp/NestedScrollViewPackage.h
@@ -85,7 +85,6 @@ namespace rnoh {
             };
         }
         EventEmitRequestHandlers createEventEmitRequestHandlers() override {
-            LOG(INFO)<<"liqi LIQIonScroll======NestedScrollViewPackage onScroll";
             return {
                 std::make_shared<NestedScrollViewEmitRequestHandler>(), 
                 std::make_shared<NestedScrollViewHeaderEmitRequestHandler>()};


### PR DESCRIPTION
# Summary
fix:修复m_layoutMetrics.frame.size.height在集成demo中获取高度不正确的问题

## Test Plan
![nestedScroll](https://github.com/user-attachments/assets/c0a6c8f8-6a19-471f-b9ae-eb91d00e3f64)


## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)